### PR TITLE
Compute scheduler overhead for each job

### DIFF
--- a/EXPERIMENTS.md
+++ b/EXPERIMENTS.md
@@ -220,7 +220,7 @@ The following commands can be used to measure the overhead of Gavel's
 implementation. These require only a single GPU.
 
 The first command sweeps through all model types and runs each model
-for 10 rounds in configurations with 1 and 2 total jobs. It saves
+for 10 rounds in configurations with and without lease extensions. It saves
 job timelines into the specified directory.
 ```bash
 python scripts/microbenchmarks/sweep_models_for_overhead.py \

--- a/EXPERIMENTS.md
+++ b/EXPERIMENTS.md
@@ -219,7 +219,7 @@ resources for a much longer duration.
 The following commands can be used to measure the overhead of Gavel's
 implementation. These require only a single GPU.
 
-The first command sweeps through all model types and runs each model
+The first script sweeps through all model types and runs each model
 for 10 rounds in configurations with and without lease extensions. It saves
 job timelines into the specified directory.
 ```bash

--- a/EXPERIMENTS.md
+++ b/EXPERIMENTS.md
@@ -214,10 +214,10 @@ required to deploy Gavel in a physical cluster is included; actually replicating
 the physical cluster experiments shown in the paper will require more
 resources for a much longer duration.
 
-### Measuring job overhead
+### Measuring Overhead of Running Jobs with Gavel's Preemptive Scheduler
 
 The following commands can be used to measure the overhead of Gavel's
-implementation. These require only a single GPU.
+preemptive scheduler. These require only a single GPU.
 
 The first script sweeps through all model types and runs each model
 for 10 rounds in configurations with and without lease extensions. It saves

--- a/EXPERIMENTS.md
+++ b/EXPERIMENTS.md
@@ -213,3 +213,25 @@ a cluster size of 6 GPUs (2 V100s and 4 K80s), and is intended merely to show th
 required to deploy Gavel in a physical cluster is included; actually replicating
 the physical cluster experiments shown in the paper will require more
 resources for a much longer duration.
+
+### Measuring job overhead
+
+The following commands can be used to measure the overhead of Gavel's
+implementation. These require only a single GPU.
+
+The first command sweeps through all model types and runs each model
+for 10 rounds in configurations with 1 and 2 total jobs. It saves
+job timelines into the specified directory.
+```bash
+python scripts/microbenchmarks/sweep_models_for_overhead.py \
+  --timeline_dir /path/to/timelines \
+  --run_dir /path/to/gavel/workloads/pytorch \
+  --data_dir /path/to/data \
+  --checkpoint_dir /path/to/checkpoints
+```
+
+The next script parses the saved timelines and computes the overhead.
+```bash
+python scripts/utils/get_job_overhead.py \
+  --timeline_dir /path/to/timelines
+```

--- a/scheduler/gavel_iterator.py
+++ b/scheduler/gavel_iterator.py
@@ -32,9 +32,9 @@ class GavelIterator:
             self._data_loader = data_loader
 
         self._write_on_close = write_on_close
+        atexit.register(self._close_file_handler)
         if self._write_on_close:
             atexit.register(self._write_info)
-        atexit.register(self._close_file_handler)
         self._verbose = verbose
         self._load_checkpoint_func = load_checkpoint_func
         self._save_checkpoint_func = save_checkpoint_func

--- a/scheduler/gavel_iterator.py
+++ b/scheduler/gavel_iterator.py
@@ -18,9 +18,11 @@ logging.getLogger('filelock').setLevel(logging.CRITICAL)
 
 INFINITY = (1e9)
 LEASE_UPDATE_FRACTION = 0.75
+LOG_FORMAT = '[{asctime}] [{event}] [{status}] {message}'
+DATE_FORMAT = '%Y-%m-%d %H:%M:%S'
 
 class GavelIterator:
-    def __init__(self, data_loader, gavel_dir, load_checkpoint_func,
+    def __init__(self, data_loader, checkpoint_dir, load_checkpoint_func,
                  save_checkpoint_func, synthetic_data=False,
                  write_on_close=True, verbose=True):
         if not isinstance(data_loader, Iterable):
@@ -37,15 +39,36 @@ class GavelIterator:
         self._save_checkpoint_func = save_checkpoint_func
         self._job_id = int(os.environ['GAVEL_JOB_ID'])
         self._worker_id = int(os.environ['GAVEL_WORKER_ID'])
+        self._round_id = int(os.environ['GAVEL_ROUND_ID'])
         self._sched_addr = os.environ['GAVEL_SCHED_ADDR']
         self._sched_port = int(os.environ['GAVEL_SCHED_PORT'])
-        self._lock_file = os.path.join(gavel_dir, '.gavel.lock')
-        self._gavel_file = os.path.join(gavel_dir, '.gavel.json')
+        self._lock_file = os.path.join(checkpoint_dir, '.gavel.lock')
         self._lock = FileLock(self._lock_file)
+        self._gavel_dir = os.path.join(checkpoint_dir, '.gavel')
+        self._round_dir = \
+            os.path.join(self._gavel_dir, 'round={0}'.format(self._round_id))
+        self._worker_dir = \
+            os.path.join(self._round_dir, 'worker={0}'.format(self._worker_id))
+        with self._lock:
+            if not os.path.isdir(self._gavel_dir):
+                os.mkdir(self._gavel_dir)
+            if not os.path.isdir(self._round_dir):
+                os.mkdir(self._round_dir)
+        self._log_file = os.path.join(self._round_dir,
+                                      'worker={0}.log'.format(self._worker_id))
+        self._logger = logging.getLogger('gavel_iterator')
+        self._logger.propagate = False
+        self._logger.setLevel(logging.DEBUG)
+        fh = logging.FileHandler(self._log_file)
+        fh.setFormatter(logging.Formatter(LOG_FORMAT, datefmt=DATE_FORMAT,
+                                          style='{'))
+        fh.setLevel(logging.DEBUG)
+        self._logger.addHandler(fh)
         self._rpc_client = \
             iterator_client.IteratorRpcClient(self._job_id, self._worker_id,
                                               self._sched_addr,
-                                              self._sched_port)
+                                              self._sched_port,
+                                              self._logger)
         self._steps = 0
         self._duration = 0
         self._synthetic_data = synthetic_data
@@ -74,19 +97,15 @@ class GavelIterator:
             self._update_lease()
 
         # Check if the lease has expired.
-        if self._duration >= self._lease.max_duration:
-            if self._verbose:
-                print('Gavel lease expired: %f seconds '
-                      '(max %f seconds)' % (self._duration,
-                                            self._lease.max_duration))
+        lease_expired = (self._duration >= self._lease.max_duration or
+                         self._steps >= self._lease.max_steps)
+        if lease_expired:
             self._done = True
-            raise StopIteration
-        elif self._steps >= self._lease.max_steps:
-            if self._verbose:
-                print('Gavel lease expired: %d steps '
-                      '(max %d steps)' % (self._steps,
-                                          self._lease.max_steps))
-            self._done = True
+            self._logger.info(
+                '{0} / {1} steps, {2:.4f} / {3:.4f} seconds'.format(
+                    self._steps, self._lease.max_steps,
+                    self._duration, self._lease.max_duration),
+                extra={'event': 'LEASE', 'status': 'EXPIRED'})
             raise StopIteration
 
         # Return a new data item if one exists.
@@ -120,36 +139,29 @@ class GavelIterator:
         self._done = True
         if not self._write_on_close:
             self._write_info()
+        self._logger.info('', extra={'event': 'LEASE', 'status': 'COMPLETE'})
 
     def load_checkpoint(self, *args, **kwargs):
-        print('[%s] Gavel loading checkpoint' % (datetime.datetime.now()))
-        return self._load_checkpoint_func(*args, **kwargs)
+        self._logger.info('', extra={'event': 'LOAD CHECKPOINT',
+                                     'status': 'BEGIN'})
+        checkpoint = self._load_checkpoint_func(*args, **kwargs)
+        self._logger.info('', extra={'event': 'LOAD CHECKPOINT',
+                                     'status': 'END'})
+        return checkpoint
 
     def save_checkpoint(self, *args, **kwargs):
-        print('[%s] Gavel saving checkpoint' % (datetime.datetime.now()))
-        return self._save_checkpoint_func(*args, **kwargs)
+        self._logger.info('', extra={'event': 'SAVE CHECKPOINT',
+                                     'status': 'BEGIN'})
+        retval = self._save_checkpoint_func(*args, **kwargs)
+        self._logger.info('', extra={'event': 'SAVE CHECKPOINT',
+                                     'status': 'END'})
+        return retval
 
     def _write_info(self):
-        job_id = str(self._job_id)
-        worker_id = str(self._worker_id)
-        with self._lock:
-            try:
-                if os.path.exists(self._gavel_file):
-                    with open(self._gavel_file, 'r') as f:
-                        gavel_info = json.load(f)
-                else:
-                    gavel_info = {}
-                if job_id not in gavel_info:
-                    gavel_info[job_id] = {}
-                if worker_id not in gavel_info[job_id]:
-                    gavel_info[job_id][worker_id] = {}
-                gavel_info[job_id][worker_id]['steps'] = self._steps
-                gavel_info[job_id][worker_id]['duration'] = self._duration
-                with open(self._gavel_file, 'w') as f:
-                    json.dump(gavel_info, f)
-            except Exception as e:
-                traceback.print_exc()
-                raise RuntimeError('Could not write Gavel info!')
+        self._logger.info('{0}'.format(self._steps),
+                          extra={'event': 'PROGRESS', 'status': 'STEPS'})
+        self._logger.info('{0}'.format(self._duration),
+                          extra={'event': 'PROGRESS', 'status': 'DURATION'})
 
     def _update_lease(self, init=False):
         if init:

--- a/scheduler/gavel_iterator.py
+++ b/scheduler/gavel_iterator.py
@@ -57,14 +57,7 @@ class GavelIterator:
                 os.mkdir(self._round_dir)
         self._log_file = os.path.join(self._round_dir,
                                       'worker={0}.log'.format(self._worker_id))
-        self._logger = logging.getLogger('gavel_iterator')
-        self._logger.propagate = False
-        self._logger.setLevel(logging.DEBUG)
-        self._file_handler = logging.FileHandler(self._log_file)
-        self._file_handler.setFormatter(
-                logging.Formatter(LOG_FORMAT, datefmt=DATE_FORMAT, style='{'))
-        self._file_handler.setLevel(logging.DEBUG)
-        self._logger.addHandler(self._file_handler)
+        self._init_logger()
         self._rpc_client = \
             iterator_client.IteratorRpcClient(self._job_id, self._worker_id,
                                               self._sched_addr,
@@ -157,6 +150,16 @@ class GavelIterator:
         self._logger.info('', extra={'event': 'SAVE CHECKPOINT',
                                      'status': 'END'})
         return retval
+
+    def _init_logger(self):
+        self._logger = logging.getLogger('gavel_iterator')
+        self._logger.propagate = False
+        self._logger.setLevel(logging.DEBUG)
+        self._file_handler = logging.FileHandler(self._log_file)
+        self._file_handler.setFormatter(
+                logging.Formatter(LOG_FORMAT, datefmt=DATE_FORMAT, style='{'))
+        self._file_handler.setLevel(logging.DEBUG)
+        self._logger.addHandler(self._file_handler)
 
     def _write_info(self):
         self._logger.info('{0}'.format(self._steps),

--- a/scheduler/runtime/protobuf/scheduler_to_worker.proto
+++ b/scheduler/runtime/protobuf/scheduler_to_worker.proto
@@ -26,4 +26,5 @@ message JobDescription {
 message RunRequest {
     repeated JobDescription job_descriptions = 1;
     uint64 worker_id = 2;
+    uint64 round_id = 3;
 }

--- a/scheduler/runtime/protobuf/worker_to_scheduler.proto
+++ b/scheduler/runtime/protobuf/worker_to_scheduler.proto
@@ -37,4 +37,5 @@ message DoneRequest {
     repeated uint64 job_id = 2;
     repeated uint64 num_steps = 3;
     repeated double execution_time = 4;
+    repeated string iterator_log = 5;
 }

--- a/scheduler/runtime/rpc/dispatcher.py
+++ b/scheduler/runtime/rpc/dispatcher.py
@@ -271,7 +271,7 @@ class Dispatcher:
             return ''
 
         with open(log_file, 'r') as f:
-            return f.read()
+            return f.read().strip()
 
     def launch_job(self, job, command, worker_id, round_id, gpu_id):
         output = ''
@@ -422,7 +422,7 @@ class Dispatcher:
                                                               gpu_id)))
             job_descriptions = [result.get() for result in results]
         else:
-            job_descriptions = [[job.job_id, -1, 0, ''] for job in jobs]
+            job_descriptions = [[job.job_id, 0, 0, ''] for job in jobs]
 
         # Cleanup and notify the scheduler.
         self._gpu_queue.put(gpu_id)

--- a/scheduler/runtime/rpc/dispatcher.py
+++ b/scheduler/runtime/rpc/dispatcher.py
@@ -177,7 +177,6 @@ class Dispatcher:
 
         steps = 0
         execution_time = 0
-        # TODO: Compute overhead
         with open(log_file, 'r') as f:
             for line in f:
                 match = re.match('\[(.*)\] \[(.*)\] \[(.*)\]\ ?(.*)', line)

--- a/scheduler/runtime/rpc/iterator_client.py
+++ b/scheduler/runtime/rpc/iterator_client.py
@@ -7,36 +7,35 @@ from lease import Lease
 
 class IteratorRpcClient:
 
-    def __init__(self, job_id, worker_id, sched_ip_addr, sched_port,
-                 verbose=True):
+    def __init__(self, job_id, worker_id, sched_ip_addr, sched_port, logger):
         self._job_id = job_id
         self._worker_id = worker_id
         self._sched_loc = '%s:%d' % (sched_ip_addr, sched_port)
-        self._verbose = verbose
-
-    def _log(self, message):
-        if self._verbose:
-            print('[Job %d | worker %d] %s' % (self._job_id,
-                                               self._worker_id,
-                                               message))
+        self._logger = logger
 
     def init(self):
         request = i2s_pb2.InitJobRequest(job_id=self._job_id)
         with grpc.insecure_channel(self._sched_loc) as channel:
             stub = i2s_pb2_grpc.IteratorToSchedulerStub(channel)
             try:
+                self._logger.info(
+                    '', extra={'event': 'INIT', 'status': 'REQUESTING'})
                 response = stub.InitJob(request)
                 if response.max_steps > 0 and response.max_duration > 0:
-                    self._log(
-                        'Initialized job %d with initial lease max_steps=%d, '
-                        'max_duration=%f' % (self._job_id, response.max_steps,
-                                             response.max_duration))
+                    self._logger.info(
+                        'Initial lease: max_steps {0}, '
+                        'max_duration={1:.4f}'.format(
+                            response.max_steps, response.max_duration),
+                        extra={'event': 'INIT', 'status': 'COMPLETE'})
                 else:
-                    self._log('Failed to initialize job %d!' % (self._job_id))
+                    self._logger.error(
+                        '', extra={'event': 'INIT', 'status': 'FAILED'})
                 return (response.max_steps, response.max_duration,
                         response.extra_time)
             except grpc.RpcError as e:
-                self._log('Job initialization error: %s' % (e))
+                self._logger.error(
+                    '{0}'.format(e),
+                    extra={'event': 'INIT', 'status': 'ERROR'})
             return (0, 0, 0)
 
     def update_lease(self, steps, duration, max_steps, max_duration):
@@ -48,14 +47,17 @@ class IteratorRpcClient:
                                              max_duration=max_duration)
         with grpc.insecure_channel(self._sched_loc) as channel:
             stub = i2s_pb2_grpc.IteratorToSchedulerStub(channel)
-            self._log('Requesting new lease')
+            self._logger.info(
+                '', extra={'event': 'LEASE', 'status': 'REQUESTING'})
             try:
                 response = stub.UpdateLease(request)
-                self._log('Received new lease: '
-                          '%d, %f' % (response.max_steps,
-                                      response.max_duration))
+                self._logger.info(
+                    'New lease: max_steps={0}, max_duration={1:.4f}'.format(
+                        response.max_steps, response.max_duration),
+                          extra={'event': 'LEASE', 'status': 'UPDATED'})
                 return (response.max_steps, response.max_duration)
             except grpc.RpcError as e:
-                self._log('UpdateLease error: %s' % (e))
-                self._log('WARNING: Failed to receive new lease!')
+                self._logger.error(
+                    '{0}'.format(e),
+                    extra={'event': 'LEASE', 'status': 'ERROR'})
         return (max_steps, max_duration)

--- a/scheduler/runtime/rpc/scheduler_client.py
+++ b/scheduler/runtime/rpc/scheduler_client.py
@@ -23,7 +23,7 @@ class SchedulerRpcClient:
     def port(self):
         return self._port
 
-    def run(self, job_descriptions, worker_id):
+    def run(self, job_descriptions, worker_id, round_id):
         with grpc.insecure_channel(self._server_loc) as channel:
             stub = s2w_pb2_grpc.SchedulerToWorkerStub(channel)
             request = s2w_pb2.RunRequest()
@@ -37,6 +37,7 @@ class SchedulerRpcClient:
                 job_description.num_steps_arg = num_steps_arg
                 job_description.num_steps = num_steps
             request.worker_id = worker_id
+            request.round_id = round_id
             response = stub.Run(request)
 
     def reset(self):

--- a/scheduler/runtime/rpc/scheduler_server.py
+++ b/scheduler/runtime/rpc/scheduler_server.py
@@ -110,7 +110,7 @@ class SchedulerIteratorRpcServer(i2s_pb2_grpc.IteratorToSchedulerServicer):
         self._logger.info(
             'Received lease update request: '
             'job_id={job_id}, worker_id={worker_id}, steps={steps}, '
-            'duration={duration:.2f}, max_steps={max_steps},'
+            'duration={duration:.2f}, max_steps={max_steps}, '
             'max_duration={max_duration:.2f}'.format(
                 job_id=job_id, worker_id=request.worker_id,
                 steps=request.steps, duration=request.duration,

--- a/scheduler/runtime/rpc/scheduler_server.py
+++ b/scheduler/runtime/rpc/scheduler_server.py
@@ -72,7 +72,8 @@ class SchedulerRpcServer(w2s_pb2_grpc.WorkerToSchedulerServicer):
                     num_steps=str(request.num_steps),
                     execution_time=str(request.execution_time)))
             done_callback(job_id, request.worker_id,
-                          request.num_steps, request.execution_time)
+                          request.num_steps, request.execution_time,
+                          request.iterator_log)
         except Exception as e:
             self._logger.error('Could not process completion '
                                'notification for job {0}'.format(job_id))

--- a/scheduler/runtime/rpc/worker_client.py
+++ b/scheduler/runtime/rpc/worker_client.py
@@ -58,10 +58,10 @@ class WorkerRpcClient:
         request = w2s_pb2.DoneRequest()
         request.worker_id = worker_id
         for job_description in job_descriptions:
-            request.job_id.append(job_description.job_id)
-            request.execution_time.append(job_description.execution_time)
-            request.num_steps.append(job_description.num_steps)
-            request.iterator_log.append(job_description.iterator_log)
+            request.job_id.append(job_description[0])
+            request.execution_time.append(job_description[1])
+            request.num_steps.append(job_description[2])
+            request.iterator_log.append(job_description[3])
         with grpc.insecure_channel(self._sched_loc) as channel:
             stub = w2s_pb2_grpc.WorkerToSchedulerStub(channel)
             response = stub.Done(request)

--- a/scheduler/runtime/rpc/worker_client.py
+++ b/scheduler/runtime/rpc/worker_client.py
@@ -57,10 +57,11 @@ class WorkerRpcClient:
         # Send a Done message.
         request = w2s_pb2.DoneRequest()
         request.worker_id = worker_id
-        for (job_id, execution_time, num_steps) in job_descriptions:
-            request.job_id.append(job_id)
-            request.execution_time.append(execution_time)
-            request.num_steps.append(num_steps)
+        for job_description in job_descriptions:
+            request.job_id.append(job_description.job_id)
+            request.execution_time.append(job_description.execution_time)
+            request.num_steps.append(job_description.num_steps)
+            request.iterator_log.append(job_description.iterator_log)
         with grpc.insecure_channel(self._sched_loc) as channel:
             stub = w2s_pb2_grpc.WorkerToSchedulerStub(channel)
             response = stub.Done(request)
@@ -68,4 +69,7 @@ class WorkerRpcClient:
               [job_description[0] for job_description in job_descriptions]
             if len(job_ids) == 1:
               self._logger.debug('Notified scheduler that '
-                                 'job {0} has completed'.format(str(job_ids)))
+                                 'job {0} has completed'.format(job_ids[0]))
+            else:
+              self._logger.debug('Notified scheduler that '
+                                 'jobs {0} have completed'.format(job_ids))

--- a/scheduler/runtime/rpc/worker_server.py
+++ b/scheduler/runtime/rpc/worker_server.py
@@ -31,7 +31,7 @@ class WorkerServer(s2w_pb2_grpc.SchedulerToWorkerServicer):
         for job_description in request.job_descriptions:
             jobs.append(job.Job.from_proto(job_description))
         run_callback = self._callbacks['Run']
-        run_callback(jobs, request.worker_id)
+        run_callback(jobs, request.worker_id, request.round_id)
         return common_pb2.Empty()
 
     def Reset(self, request, context):

--- a/scheduler/scheduler.py
+++ b/scheduler/scheduler.py
@@ -2553,7 +2553,7 @@ class Scheduler:
                 self._scheduler_cv.notifyAll()
 
     def _done_callback(self, job_id, worker_id, all_num_steps,
-                       all_execution_times):
+                       all_execution_times, all_iterator_logs=None):
         """Handles completion of a scheduled job.
 
         Updates the running total of completed steps and time spent on each
@@ -2565,6 +2565,8 @@ class Scheduler:
             job_id: The id of the completed job(s).
             worker_id: The id of the worker where the job(s) were completed.
             all_num_steps: List of the number of steps each job ran for.
+            all_execution_times: List of the duration each job ran for.
+            all_iterator_logs: List of the GavelIterator logs for each job.
         """
 
         to_remove = []

--- a/scheduler/scheduler.py
+++ b/scheduler/scheduler.py
@@ -2284,15 +2284,6 @@ class Scheduler:
                 elapsed_job_time[job_id][worker_type] += elapsed_time
                 elapsed_worker_time[worker_type] += elapsed_time
 
-            for job_id in elapsed_job_time:
-                self._logger.debug('Elapsed time for job {0}: {1}'.format(
-                    job_id, elapsed_job_time[job_id]))
-            for worker_type in elapsed_worker_time:
-                self._logger.debug('Elapsed time for worker type {0}: '
-                                   '{1}'.format(
-                                       worker_type,
-                                       elapsed_worker_time[worker_type]))
-
         # Stores the fraction of time spent running a job for each worker.
         fractions = {}
 

--- a/scheduler/scheduler.py
+++ b/scheduler/scheduler.py
@@ -1827,6 +1827,15 @@ class Scheduler:
             print('Number of SLO violations: %d' % (num_SLO_violations))
         return num_SLO_violations
 
+    def get_job_overheads(self):
+        # TODO: Compute overhead
+        print('Job timelines:\n')
+        for job_id in sorted(self._timelines.keys()):
+            print('Job {0}'.format(job_id))
+            for event in self._timelines[job_id]:
+                print(event)
+            print('')
+
     def get_micro_tasks(self):
         """Prints all micro-tasks run for each job.
 

--- a/scheduler/scheduler.py
+++ b/scheduler/scheduler.py
@@ -2314,10 +2314,6 @@ class Scheduler:
                         job_time_so_far += \
                             elapsed_job_time[job_id][worker_type]
                     fraction = job_time_so_far / worker_time_so_far
-                    self._logger.debug('Job {0} fraction: '
-                                       '{1:.2f} / {2:.2f} = {3:.2f}'.format(
-                                           job_id, job_time_so_far,
-                                           worker_time_so_far, fraction))
                 fractions[worker_type][job_id] = fraction
             for job_id in self._priorities[worker_type]:
                 # Don't use inf so 2*new_priority > new_priority.
@@ -2339,11 +2335,6 @@ class Scheduler:
                     elif fractions[worker_type][job_id] > 0.0:
                         new_priority = self._allocation[job_id][worker_type] /\
                                 fractions[worker_type][job_id]
-                        self._logger.debug(
-                            'Job {0} new priority: '
-                            '{1:.2f} / {2:.2f} = {3:.2f}'.format(
-                                job_id, self._allocation[job_id][worker_type],
-                                fractions[worker_type][job_id], new_priority))
                     self._priorities[worker_type][job_id] = new_priority
 
     def _add_available_worker_id(self, worker_id):

--- a/scheduler/scheduler.py
+++ b/scheduler/scheduler.py
@@ -1553,6 +1553,7 @@ class Scheduler:
                     master_job_port
 
         # Dispatch the job.
+        current_round = self._num_completed_rounds
         for i, worker_id in enumerate(worker_ids):
             job_descriptions = []
             for j, single_job_id in enumerate(job_id.singletons()):
@@ -1577,7 +1578,7 @@ class Scheduler:
                          self._jobs[single_job_id].num_steps_arg,
                          num_steps))
             self._worker_connections[worker_id].run(job_descriptions,
-                                                    worker_id)
+                                                    worker_id, current_round)
             if not next_round:
                 self._remove_available_worker_id(worker_id)
 

--- a/scheduler/scheduler.py
+++ b/scheduler/scheduler.py
@@ -1842,17 +1842,17 @@ class Scheduler:
             print('Number of SLO violations: %d' % (num_SLO_violations))
         return num_SLO_violations
 
-    def save_job_timelines(self, timelines_dir):
-        if not os.path.isdir(timelines_dir):
+    def save_job_timelines(self, timeline_dir):
+        if not os.path.isdir(timeline_dir):
             try:
-                os.mkdir(timelines_dir)
+                os.mkdir(timeline_dir)
             except Exception as e:
                 self._logger.error('Could not save timelines!')
                 traceback.print_exc()
                 return
 
         for job_id in sorted(self._job_timelines.keys()):
-            job_dir = os.path.join(timelines_dir, 'job_id={0}'.format(job_id))
+            job_dir = os.path.join(timeline_dir, 'job_id={0}'.format(job_id))
             if not os.path.isdir(job_dir):
                 os.mkdir(job_dir)
             for i in range(len(self._job_timelines[job_id])):

--- a/scheduler/scheduler.py
+++ b/scheduler/scheduler.py
@@ -453,7 +453,7 @@ class Scheduler:
             self._steps_run_so_far[job_id] = {}
             self._job_time_so_far[job_id] = {}
             self._job_cost_so_far[job_id] = 0.0
-            self._timelines[job_id] = []
+            self._job_timelines[job_id] = []
             self._throughputs[job_id] = {}
             job_type = self._jobs[job_id].job_type
             scale_factor = job.scale_factor
@@ -1830,9 +1830,9 @@ class Scheduler:
     def get_job_overheads(self):
         # TODO: Compute overhead
         print('Job timelines:\n')
-        for job_id in sorted(self._timelines.keys()):
+        for job_id in sorted(self._job_timelines.keys()):
             print('Job {0}'.format(job_id))
-            for event in self._timelines[job_id]:
+            for event in self._job_timelines[job_id]:
                 print(event)
             print('')
 
@@ -2597,7 +2597,7 @@ class Scheduler:
             if all_iterator_logs is not None:
                 for i, single_job_id in enumerate(job_id.singletons()):
                     events = all_iterator_logs[i].split('\n')
-                    self._timelines[single_job_id].extend(events)
+                    self._job_timelines[single_job_id].extend(events)
 
             # Check whether jobs are still active as jobs might have
             # completed after being dispatched for the subsequent round.

--- a/scheduler/scheduler.py
+++ b/scheduler/scheduler.py
@@ -1833,11 +1833,10 @@ class Scheduler:
         for job_id in sorted(self._job_timelines.keys()):
             print('Job {0}:'.format(job_id))
             for i in range(len(self._job_timelines[job_id])):
-                print('Worker {0}'.format(i))
+                print('Worker {0}:'.format(i))
                 for event in self._job_timelines[job_id][i]:
                     print(event)
             print('')
-        print('')
 
     def get_micro_tasks(self):
         """Prints all micro-tasks run for each job.
@@ -2675,8 +2674,9 @@ class Scheduler:
                         all_num_steps[j] += all_num_steps_[j]
                         all_execution_times[j] = max(all_execution_times[j],
                                                      all_execution_times_[j])
-                        self._job_timelines[single_job_id][i].extend(
-                            all_iterator_logs_[j])
+                        if all_iterator_logs_ is not None:
+                            self._job_timelines[single_job_id][i].extend(
+                                all_iterator_logs_[j].split('\n'))
 
             # Reset metadata for distributed jobs.
             self._in_progress_updates[job_id] = []

--- a/scheduler/scheduler.py
+++ b/scheduler/scheduler.py
@@ -13,7 +13,6 @@ import threading
 import time
 import datetime
 import random
-import re
 import sched
 import math
 import matrix_completion

--- a/scheduler/scheduler.py
+++ b/scheduler/scheduler.py
@@ -2693,8 +2693,8 @@ class Scheduler:
                     all_num_steps_ = update[1]
                     all_execution_times_ = update[2]
                     all_iterator_logs_ = update[3]
-                    for j in range(len(job_id.singletons())):
-                        if not is_active[job_id.singletons()[j]]:
+                    for j, single_job_id in enumerate(job_id.singletons()):
+                        if not is_active[single_job_id]:
                             continue
                         elif (all_num_steps_[j] <= 0 or
                               all_execution_times_[j] <= 0):

--- a/scheduler/scripts/drivers/run_scheduler_with_trace.py
+++ b/scheduler/scripts/drivers/run_scheduler_with_trace.py
@@ -63,6 +63,7 @@ def main(args):
         sched.get_average_jct(jobs_to_complete)
         sched.get_completed_steps(jobs_to_complete)
         sched.get_cluster_utilization()
+        sched.get_job_overheads()
         elapsed_time = (datetime.datetime.now() - start_time).seconds
         print('Total time taken: %d seconds' % (elapsed_time))
     except KeyboardInterrupt as e:

--- a/scheduler/scripts/drivers/run_scheduler_with_trace.py
+++ b/scheduler/scripts/drivers/run_scheduler_with_trace.py
@@ -63,8 +63,8 @@ def main(args):
         sched.get_average_jct(jobs_to_complete)
         sched.get_completed_steps(jobs_to_complete)
         sched.get_cluster_utilization()
-        if args.timelines_dir is not None:
-            sched.save_job_timelines(args.timelines_dir)
+        if args.timeline_dir is not None:
+            sched.save_job_timelines(args.timeline_dir)
         elapsed_time = (datetime.datetime.now() - start_time).seconds
         print('Total time taken: %d seconds' % (elapsed_time))
     except KeyboardInterrupt as e:
@@ -96,6 +96,6 @@ if __name__=='__main__':
                         help='Measurement window end (job ID)')
     parser.add_argument('--max_rounds', type=int, default=None,
                         help='Maximum number of rounds to run')
-    parser.add_argument('--timelines_dir', type=str, default=None,
+    parser.add_argument('--timeline_dir', type=str, default=None,
                         help='Directory to save timelnes to')
     main(parser.parse_args())

--- a/scheduler/scripts/drivers/run_scheduler_with_trace.py
+++ b/scheduler/scripts/drivers/run_scheduler_with_trace.py
@@ -63,7 +63,8 @@ def main(args):
         sched.get_average_jct(jobs_to_complete)
         sched.get_completed_steps(jobs_to_complete)
         sched.get_cluster_utilization()
-        sched.get_job_overheads()
+        if args.timelines_dir is not None:
+            sched.save_job_timelines(args.timelines_dir)
         elapsed_time = (datetime.datetime.now() - start_time).seconds
         print('Total time taken: %d seconds' % (elapsed_time))
     except KeyboardInterrupt as e:
@@ -95,4 +96,6 @@ if __name__=='__main__':
                         help='Measurement window end (job ID)')
     parser.add_argument('--max_rounds', type=int, default=None,
                         help='Maximum number of rounds to run')
+    parser.add_argument('--timelines_dir', type=str, default=None,
+                        help='Directory to save timelnes to')
     main(parser.parse_args())

--- a/scheduler/scripts/microbenchmarks/sweep_models_for_overhead.py
+++ b/scheduler/scripts/microbenchmarks/sweep_models_for_overhead.py
@@ -36,7 +36,7 @@ async def run(cmd, sleep_seconds=None):
 def main(args):
     loop = asyncio.get_event_loop()
     max_rounds = args.max_rounds
-    timelines_dir = args.timelines_dir
+    timeline_dir = args.timeline_dir
     trace_file = '/tmp/overhead.trace'
     models = [
         ('ResNet-18 (batch size 256)', 'resnet18'),
@@ -49,7 +49,7 @@ def main(args):
     ]
 
     for (model, model_dir) in models:
-        model_dir = os.path.join(timelines_dir, 'model={0}'.format(model_dir))
+        model_dir = os.path.join(timeline_dir, 'model={0}'.format(model_dir))
         if not os.path.isdir(model_dir):
             os.mkdir(model_dir)
 
@@ -86,7 +86,7 @@ def main(args):
             scheduler_cmd = BASE_SCHEDULER_COMMAND
             scheduler_cmd += ' --max_rounds {0}'.format(max_rounds)
             scheduler_cmd += ' --trace_file {0}'.format(trace_file)
-            scheduler_cmd += ' --timelines_dir {0}'.format(num_jobs_dir)
+            scheduler_cmd += ' --timeline_dir {0}'.format(num_jobs_dir)
             worker_cmd = BASE_WORKER_COMMAND
             worker_cmd += ' --run_dir {0}'.format(args.run_dir)
             worker_cmd += ' --data_dir {0}'.format(args.data_dir)
@@ -102,7 +102,7 @@ if __name__=='__main__':
                     'measuring overhead')
     parser.add_argument('--max_rounds', type=int, default=10,
                         help='Maximum number of rounds to run')
-    parser.add_argument('--timelines_dir', type=str, required=True,
+    parser.add_argument('--timeline_dir', type=str, required=True,
                         help='Root directory to write timelines to')
     parser.add_argument('--run_dir', type=str, required=True,
                         help='Directory to run jobs from')

--- a/scheduler/scripts/microbenchmarks/sweep_models_for_overhead.py
+++ b/scheduler/scripts/microbenchmarks/sweep_models_for_overhead.py
@@ -23,16 +23,6 @@ BASE_WORKER_COMMAND = \
     """python worker.py -i 127.0.1.1 -s 50060 -w 50061 -g 1 -t p100"""
 INFINITY = 10000000000
 
-def get_overhead(line):
-    pattern = ('Job (\d+): Total time=([-+]?[0-9]*\.?[0-9]+) seconds, '
-               'Computation time=([-+]?[0-9]*\.?[0-9]+) seconds, '
-               'Overhead=([-+]?[0-9]*\.?[0-9]+)%')
-    match = re.match(pattern, line)
-    if match is None:
-        return None
-    return (int(match.group(1)), float(match.group(2)), float(match.group(3)),
-            float(match.group(4)))
-
 async def run(cmd, sleep_seconds=None):
     if sleep_seconds is not None:
         time.sleep(sleep_seconds)

--- a/scheduler/scripts/microbenchmarks/sweep_models_for_overhead.py
+++ b/scheduler/scripts/microbenchmarks/sweep_models_for_overhead.py
@@ -48,6 +48,9 @@ def main(args):
         ('CycleGAN', 'cyclegan'),
     ]
 
+    if not os.path.isdir(timeline_dir):
+        os.mkdir(timeline_dir)
+
     for (model, model_dir) in models:
         model_dir = os.path.join(timeline_dir, 'model={0}'.format(model_dir))
         if not os.path.isdir(model_dir):

--- a/scheduler/scripts/microbenchmarks/sweep_models_for_overhead.py
+++ b/scheduler/scripts/microbenchmarks/sweep_models_for_overhead.py
@@ -1,0 +1,124 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.realpath(__file__)))))
+
+import argparse
+import asyncio
+import numpy as np
+import re
+import time
+
+from job import Job
+from job_id_pair import JobIdPair
+from job_table import JobTable
+
+BASE_SCHEDULER_COMMAND = \
+    """python scripts/drivers/run_scheduler_with_trace.py \
+        --seed 0 \
+        --solver ECOS \
+        --throughputs_file physical_cluster_throughputs.json \
+        --time_per_iteration 360 \
+        --policy max_min_fairness \
+        --expected_num_workers 1"""
+BASE_WORKER_COMMAND = \
+    """python worker.py -i 127.0.1.1 -s 50060 -w 50061 -g 1 -t p100"""
+INFINITY = 10000000000
+
+def get_overhead(line):
+    pattern = ('Job (\d+): Total time=([-+]?[0-9]*\.?[0-9]+) seconds, '
+               'Computation time=([-+]?[0-9]*\.?[0-9]+) seconds, '
+               'Overhead=([-+]?[0-9]*\.?[0-9]+)%')
+    match = re.match(pattern, line)
+    if match is None:
+        return None
+    return (int(match.group(1)), float(match.group(2)), float(match.group(3)),
+            float(match.group(4)))
+
+async def run(cmd, sleep_seconds=None):
+    if sleep_seconds is not None:
+        time.sleep(sleep_seconds)
+    proc = \
+        await asyncio.create_subprocess_shell(
+            cmd, stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE)
+    stdout, stderr = await proc.communicate()
+    return (stdout, stderr)
+
+def main(args):
+    loop = asyncio.get_event_loop()
+    max_rounds = args.max_rounds
+    timelines_dir = args.timelines_dir
+    trace_file = '/tmp/overhead.trace'
+    models = [
+        ('ResNet-18 (batch size 256)', 'resnet18'),
+        ('ResNet-50 (batch size 128)', 'resnet50'),
+        ('Transformer (batch size 256)', 'transformer'),
+        ('LM (batch size 80)', 'lm'),
+        ('Recommendation (batch size 8192)', 'recommendation'),
+        ('A3C', 'a3c'),
+        ('CycleGAN', 'cyclegan'),
+    ]
+
+    for (model, model_dir) in models:
+        model_dir = os.path.join(timelines_dir, 'model={0}'.format(model_dir))
+        if not os.path.isdir(model_dir):
+            os.mkdir(model_dir)
+
+        for job_template in JobTable:
+            if job_template.model == model:
+                break
+        if job_template.model != model:
+            print('Could not find model {0} in JobTable!'.format(model))
+            continue
+
+        jobs = []
+        for num_jobs in [1, 2]:
+            job = Job(job_id=JobIdPair(num_jobs-1, None),
+                      job_type=model,
+                      command=job_template.command,
+                      working_directory=job_template.working_directory,
+                      num_steps_arg=job_template.num_steps_arg,
+                      total_steps=INFINITY,
+                      duration=3600,
+                      scale_factor=1,
+                      priority_weight=1,
+                      SLO=None,
+                      needs_data_dir=job_template.needs_data_dir)
+
+            mode = 'w' if num_jobs == 1 else 'a'
+            with open(trace_file, mode) as f:
+                f.write('{0}\t{1}\n'.format(str(job), 0))
+
+            num_jobs_dir = \
+                os.path.join(model_dir, 'num_jobs={0}'.format(num_jobs))
+            if not os.path.isdir(num_jobs_dir):
+                os.mkdir(num_jobs_dir)
+
+            scheduler_cmd = BASE_SCHEDULER_COMMAND
+            scheduler_cmd += ' --max_rounds {0}'.format(max_rounds)
+            scheduler_cmd += ' --trace_file {0}'.format(trace_file)
+            scheduler_cmd += ' --timelines_dir {0}'.format(num_jobs_dir)
+            worker_cmd = BASE_WORKER_COMMAND
+            worker_cmd += ' --run_dir {0}'.format(args.run_dir)
+            worker_cmd += ' --data_dir {0}'.format(args.data_dir)
+            worker_cmd += ' --checkpoint_dir {0}'.format(args.checkpoint_dir)
+
+            print('Running {0} with {1} jobs...'.format(model, num_jobs))
+            loop.run_until_complete(
+                asyncio.gather(run(scheduler_cmd), run(worker_cmd, 1)))
+
+if __name__=='__main__':
+    parser = argparse.ArgumentParser(
+        description='Sweep models to collect job timelines for '
+                    'measuring overhead')
+    parser.add_argument('--max_rounds', type=int, default=10,
+                        help='Maximum number of rounds to run')
+    parser.add_argument('--timelines_dir', type=str, required=True,
+                        help='Root directory to write timelines to')
+    parser.add_argument('--run_dir', type=str, required=True,
+                        help='Directory to run jobs from')
+    parser.add_argument('--data_dir', type=str, required=True,
+                        help='Directory where data is stored')
+    parser.add_argument('--checkpoint_dir', type=str, required=True,
+                        help='Directory where checkpoints is stored')
+    args = parser.parse_args()
+    main(args)

--- a/scheduler/scripts/utils/get_job_overheads.py
+++ b/scheduler/scripts/utils/get_job_overheads.py
@@ -70,7 +70,23 @@ def main(args):
             print()
 
 if __name__=='__main__':
-    parser = argparse.ArgumentParser(description='Get overhead from timelines')
+    description = """
+Gets overhead from timelines.
+
+This requires the following directory structure, which is used
+by scripts/microbenchmarks/sweep_models_for_overhead.py:
+|-> timelines_dir
+  |-> model=modelA
+    |-> num_jobs=1
+      |-> job_id=0
+        |-> worker0.log
+
+This is also limited to measuring the overhead for jobs running
+on a single GPU, as multi-GPU configurations enable job launch latency
+hiding which we do not include in this analysis."""
+    parser = argparse.ArgumentParser(
+            description=description,
+            formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument('--timeline_dir', required=True, type=str,
                         help='Root timeline directory')
     args = parser.parse_args()

--- a/scheduler/scripts/utils/get_job_overheads.py
+++ b/scheduler/scripts/utils/get_job_overheads.py
@@ -1,0 +1,77 @@
+import argparse
+import datetime
+import os
+import re
+
+def get_job_overhead(timeline):
+    computation_time = 0.0
+    total_time = 0.0
+    current_dispatch_start_time = None
+    current_compute_start_time = None
+    for (timestamp, event, status, _) in timeline:
+        if event == 'DISPATCHER' and status == 'LAUNCH':
+            if current_dispatch_start_time is None:
+                current_dispatch_start_time = timestamp
+        elif event == 'INIT' and status == 'COMPLETE':
+            current_compute_start_time = timestamp
+        elif event == 'SAVE CHECKPOINT' and status == 'END':
+            delta = (timestamp - current_compute_start_time)
+            computation_time += delta.total_seconds()
+            current_compute_start_time = None
+        elif event == 'DISPATCHER' and status == 'COMPLETE':
+            delta = (timestamp - current_dispatch_start_time)
+            total_time += delta.total_seconds()
+            current_dispatch_start_time = None
+    if total_time == 0.0:
+        computation_time = 0.0
+    elif computation_time == 0.0:
+        total_time = 0.0
+    return (computation_time, total_time)
+
+def parse_timeline_file(timeline_file):
+    with open(timeline_file, 'r') as f:
+        lines = f.read().strip().split('\n')
+    timeline = []
+    for line in lines:
+        match = re.match('\[(.*)\] \[(.*)\] \[(.*)\]\ ?(.*)', line)
+        if match is None:
+            self._logger.error(
+                'Malformed log line: {0}'.format(line))
+            continue
+        timestamp = datetime.datetime.strptime(match.group(1),
+                                               '%Y-%m-%d %H:%M:%S')
+        event = match.group(2)
+        status = match.group(3)
+        message = match.group(4)
+        timeline.append((timestamp, event, status, message))
+    timeline.sort(key=lambda x: x[0])
+    return timeline
+
+def main(args):
+    if not os.path.isdir(args.timeline_dir):
+        raise ValueError(
+            'Invalid timeline directory \"{0}\"'.format(args.timeline_dir))
+    for model in os.listdir(args.timeline_dir):
+        model_dir = os.path.join(args.timeline_dir, model)
+        for num_jobs in os.listdir(model_dir):
+            num_jobs_dir = os.path.join(model_dir, num_jobs)
+            print('{0}, {1}'.format(model, num_jobs))
+            for i, job in enumerate(sorted(os.listdir(num_jobs_dir))):
+                job_dir = os.path.join(num_jobs_dir, job)
+                for j, worker in enumerate(sorted(os.listdir(job_dir))):
+                    timeline_file = os.path.join(job_dir, worker)
+                    timeline = parse_timeline_file(timeline_file)
+                    (computation_time, total_time) = get_job_overhead(timeline)
+                    overhead = (total_time - computation_time) / total_time
+                    print('Job {0}, worker {1}: computation time={2:.2f}, '
+                          'total time={3:.2f}, overhead={4:.2f}%'.format(
+                            i, j, computation_time, total_time,
+                            100.0 * overhead))
+            print()
+
+if __name__=='__main__':
+    parser = argparse.ArgumentParser(description='Get overhead from timelines')
+    parser.add_argument('--timeline_dir', required=True, type=str,
+                        help='Root timeline directory')
+    args = parser.parse_args()
+    main(args)

--- a/scheduler/worker.py
+++ b/scheduler/worker.py
@@ -83,7 +83,7 @@ class Worker:
 
         self._server_thread.join()
 
-    def _run_callback(self, jobs, worker_id):
+    def _run_callback(self, jobs, worker_id, round_id):
         # hack to prevent a job being dispatched before the dispatcher is set up
         # TODO: fix this by sending a "I'm ready" message to scheduler
         while True:
@@ -93,7 +93,7 @@ class Worker:
             except Exception as e:
               continue
         self._logger.debug('Dispatching run request')
-        self._dispatcher.dispatch_jobs(jobs, worker_id)
+        self._dispatcher.dispatch_jobs(jobs, worker_id, round_id)
 
     def _signal_handler(self, sig, frame):
         self._dispatcher.shutdown()

--- a/workloads/pytorch/language_modeling/main.py
+++ b/workloads/pytorch/language_modeling/main.py
@@ -172,7 +172,6 @@ def load_checkpoint(args, checkpoint_path):
         with open(checkpoint_path, 'rb') as f:
             state = torch.load(f, map_location='cuda:{}'.format(args.local_rank))
             return state
-        load_from_checkpoint = True
     except Exception as e:
         print('Could not load from checkpoint: %s' % (e))
         return None
@@ -238,6 +237,8 @@ if args.checkpoint_dir is not None:
                 state = load_checkpoint(args, checkpoint_path)
 if state is not None:
     model = state['model'].to(device)
+    if model is None:
+        raise RuntimeError('Failed to get model from checkpoint!')
 else:
     model = model.RNNModel(args.model, ntokens, args.emsize, args.nhid,
                            args.nlayers, args.dropout, args.tied).to(device)

--- a/workloads/pytorch/rl/main.py
+++ b/workloads/pytorch/rl/main.py
@@ -228,8 +228,6 @@ if __name__ == '__main__':
         for p in processes[1:]:
             p.terminate()
             p.join()
-    state = shared_model.state_dict()
-    if args.enable_gavel_iterator:
-        iters[0].save_checkpoint(state, checkpoint_path)
-    else:
+    if not args.enable_gavel_iterator:
+        state = shared_model.state_dict()
         save_checkpoint(state, checkpoint_path)

--- a/workloads/pytorch/rl/main.py
+++ b/workloads/pytorch/rl/main.py
@@ -161,6 +161,7 @@ def load_checkpoint(args, checkpoint_path):
         return None
 
 def save_checkpoint(state, checkpoint_path):
+    import torch
     print('Saving checkpoint at %s...' % (checkpoint_path))
     torch.save(state, checkpoint_path)
 
@@ -217,9 +218,12 @@ if __name__ == '__main__':
 
     time.sleep(0.1)
     for rank in range(0, args.workers):
+        if args.enable_gavel_iterator and rank == 0:
+            iters[rank]._close_file_handler()
         iters_ = dill.dumps(iters[rank])
         p = mp.Process(
-            target=train, args=(rank, args, shared_model, optimizer, env_conf, iters_))
+            target=train, args=(rank, args, shared_model, optimizer, env_conf,
+                                iters_, checkpoint_path))
         p.start()
         processes.append(p)
         time.sleep(0.1)

--- a/workloads/pytorch/rl/train.py
+++ b/workloads/pytorch/rl/train.py
@@ -12,8 +12,10 @@ import os
 import sys
 import time
 
-def train(rank, args, shared_model, optimizer, env_conf, iters):
+def train(rank, args, shared_model, optimizer, env_conf, iters, checkpoint_path):
     iters = dill.loads(iters)
+    if args.enable_gavel_iterator and rank == 0:
+        iters._init_logger()
     ptitle('Training Agent: {}'.format(rank))
     gpu_id = args.gpu_ids[rank % len(args.gpu_ids)]
     torch.manual_seed(args.seed + rank)
@@ -126,5 +128,5 @@ def train(rank, args, shared_model, optimizer, env_conf, iters):
             break
     if args.enable_gavel_iterator and rank == 0:
         state = shared_model.state_dict()
-        iters[0].save_checkpoint(state, checkpoint_path)
+        iters.save_checkpoint(state, checkpoint_path)
         iters.complete()

--- a/workloads/pytorch/rl/train.py
+++ b/workloads/pytorch/rl/train.py
@@ -124,5 +124,7 @@ def train(rank, args, shared_model, optimizer, env_conf, iters):
         if (args.max_duration is not None and
             elapsed_time >= args.max_duration):
             break
-    if args.enable_gavel_iterator:
+    if args.enable_gavel_iterator and rank == 0:
+        state = shared_model.state_dict()
+        iters[0].save_checkpoint(state, checkpoint_path)
         iters.complete()

--- a/workloads/pytorch/translation/train.py
+++ b/workloads/pytorch/translation/train.py
@@ -251,18 +251,6 @@ def train(model, training_data, validation_data, optimizer, device, opt):
             'epoch': epoch_i,
         }
 
-        if not opt.distributed or opt.rank == 0:
-            if opt.save_mode == 'all':
-                if opt.enable_gavel_iterator:
-                    training_data.save_checkpoint(checkpoint, checkpoint_path)
-                else:
-                    save_checkpoint(checkpoint, checkpoint_path)
-            elif opt.save_mode == 'best':
-                if valid_accu >= max(valid_accus):
-                    print('Saving checkpoint at %s...' % (checkpoint_path))
-                    torch.save(checkpoint, checkpoint_path)
-                    print('    - [Info] The checkpoint file has been updated.')
-
         if log_train_file:#and log_valid_file:
             with open(log_train_file, 'a') as log_tf, open(log_valid_file, 'a') as log_vf:
                 log_tf.write('{epoch},{loss: 8.5f},{ppl: 8.5f},{accu:3.3f}\n'.format(
@@ -279,9 +267,22 @@ def train(model, training_data, validation_data, optimizer, device, opt):
             elif done:
                 # Early stop.
                 training_data.complete()
-                return
+                break
         elif done:
-            return
+            break
+
+    if not opt.distributed or opt.rank == 0:
+        if opt.save_mode == 'all':
+            if opt.enable_gavel_iterator:
+                training_data.save_checkpoint(checkpoint, checkpoint_path)
+            else:
+                save_checkpoint(checkpoint, checkpoint_path)
+        elif opt.save_mode == 'best':
+            if valid_accu >= max(valid_accus):
+                print('Saving checkpoint at %s...' % (checkpoint_path))
+                torch.save(checkpoint, checkpoint_path)
+                print('    - [Info] The checkpoint file has been updated.')
+
 
 def main():
     ''' Main function '''

--- a/workloads/pytorch/translation/train.py
+++ b/workloads/pytorch/translation/train.py
@@ -263,7 +263,7 @@ def train(model, training_data, validation_data, optimizer, device, opt):
                 """
         if opt.enable_gavel_iterator:
             if training_data.done:
-                return
+                break
             elif done:
                 # Early stop.
                 training_data.complete()


### PR DESCRIPTION
List of significant changes:
- Route all `GavelIterator` logging through a single file per worker / job / round
- Format `GavelIterator` logs as a timeline, where each line is of the form `[TIMESTAMP] [EVENT] [STATUS] MESSAGE`
- Add code in `scheduler.py` to save job timelines to files
- Fix bug where latest job timestamp was being updated every round even when job was granted lease extensions
- Re-dispatch jobs with extended leases if they finish early
- Break out of scheduling loop in final round
- Add sweep script for generating timelines which can be used to measure overhead
- Add script for parsing timelines to compute overhead
- Miscellaneous bug fixes for application code