### PR TITLE
Replaced deprecated sklearn package

### DIFF
--- a/scheduler/requirements.txt
+++ b/scheduler/requirements.txt
@@ -18,6 +18,6 @@ preconditions
 psutil
 seaborn
 setproctitle
-sklearn
+scikit-learn
 torch==1.4.0
 torchvision==0.5.0


### PR DESCRIPTION
Fixes the `python setup.py egg_info did not run successfully` error while running `pip install -r scheduler/requirements.txt`.
Replaces `sklearn` with `scikit-learn` in `requirements.txt`.
`sklearn` is deprecated (see here: https://pypi.org/project/sklearn/)